### PR TITLE
addCompactConstraints: to return an NSArray with the constraints created.

### DIFF
--- a/CompactConstraint/UIView+CompactConstraint.h
+++ b/CompactConstraint/UIView+CompactConstraint.h
@@ -8,10 +8,7 @@
 @interface UIView (CompactConstraint)
 
 - (NSLayoutConstraint *)addCompactConstraint:(NSString *)relationship metrics:(NSDictionary *)metrics views:(NSDictionary *)views;
-
-- (NSArray *)addCompactConstraints:(NSArray *)relationshipStrings
-                           metrics:(NSDictionary *)metrics
-                             views:(NSDictionary *)views;
+- (NSArray *)addCompactConstraints:(NSArray *)relationshipStrings metrics:(NSDictionary *)metrics views:(NSDictionary *)views;
 
 // And a convenient shortcut for what we always end up doing with the visualFormat call.
 - (void)addConstraintsWithVisualFormat:(NSString *)format options:(NSLayoutFormatOptions)opts metrics:(NSDictionary *)metrics views:(NSDictionary *)views;

--- a/CompactConstraint/UIView+CompactConstraint.m
+++ b/CompactConstraint/UIView+CompactConstraint.m
@@ -14,16 +14,11 @@
     return constraint;
 }
 
-- (NSArray *)addCompactConstraints:(NSArray *)relationshipStrings
-                           metrics:(NSDictionary *)metrics
-                             views:(NSDictionary *)views;
+- (NSArray *)addCompactConstraints:(NSArray *)relationshipStrings metrics:(NSDictionary *)metrics views:(NSDictionary *)views;
 {
     NSMutableArray *mConstraints = [NSMutableArray arrayWithCapacity:relationshipStrings.count];
-    for (NSString  *relationship in relationshipStrings)
-        [mConstraints addObject:[NSLayoutConstraint compactConstraint:relationship
-                                                              metrics:metrics
-                                                                views:views]];
-    NSArray        *constraints  = [mConstraints copy];
+    for (NSString *relationship in relationshipStrings) [mConstraints addObject:[NSLayoutConstraint compactConstraint:relationship metrics:metrics views:views]];
+    NSArray *constraints = [mConstraints copy];
     [self addConstraints:constraints];
     return constraints;
 }


### PR DESCRIPTION
When doing animations using Auto-Layout I usually need to keep track of the existing constraints. In this way I can easily remove old constraints and add the new ones and have the layout change occur on an animation block.

I have modified the addCompactConstraints: so it returns an array with all the constraints created in the call. I thought you might find it useful (or not!).
