### PR TITLE
Support standard spacing

### DIFF
--- a/CompactConstraint/NSLayoutConstraint+CompactConstraint.h
+++ b/CompactConstraint/NSLayoutConstraint+CompactConstraint.h
@@ -3,6 +3,9 @@
 //  Copyright (c) 2014 Marco Arment. See included LICENSE file.
 //
 
+@import UIKit;
+@import Foundation;
+
 @interface NSLayoutConstraint (CompactConstraint)
 
 + (instancetype)compactConstraint:(NSString *)relationship metrics:(NSDictionary *)metrics views:(NSDictionary *)views self:(id)selfView;

--- a/CompactConstraint/NSLayoutConstraint+CompactConstraint.h
+++ b/CompactConstraint/NSLayoutConstraint+CompactConstraint.h
@@ -7,6 +7,8 @@
 
 + (instancetype)compactConstraint:(NSString *)relationship metrics:(NSDictionary *)metrics views:(NSDictionary *)views self:(id)selfView;
 + (NSArray *)compactConstraints:(NSArray *)relationshipStrings metrics:(NSDictionary *)metrics views:(NSDictionary *)views self:(id)selfView;
++ (void) setStandardSpacingToSuperview:(CGFloat)value;
++ (void) setStandardSpacingToView:(CGFloat)value;
 
 // Deprecated, will be removed shortly:
 + (instancetype)compactConstraint:(NSString *)relationship metrics:(NSDictionary *)metrics views:(NSDictionary *)views       __attribute__ ((deprecated));

--- a/CompactConstraint/NSLayoutConstraint+CompactConstraint.m
+++ b/CompactConstraint/NSLayoutConstraint+CompactConstraint.m
@@ -204,8 +204,7 @@ static CGFloat standardSpacingToView = 8.;
     if ([scanner scanCharactersFromSet:priorityOperatorCharacterSet intoString:NULL]) {
         if (! [scanner scanDouble:&priority]) {
             // see if the priority is a metric instead of a literal number
-            BOOL priorityAfterAt = [scanner scanUpToCharactersFromSet:rightOperandTerminatingCharacterSet intoString:&rightValueStr];
-            NSAssert(priorityAfterAt, @"No priority given after '@' on right side");
+            NSAssert([scanner scanUpToCharactersFromSet:rightOperandTerminatingCharacterSet intoString:&rightValueStr], @"No priority given after '@' on right side");
             rightMetricNumber = metrics[rightValueStr];
             NSAssert1(rightMetricNumber, @"Right priority '%@' not found in metrics dictionary", rightValueStr);
             priority = [rightMetricNumber doubleValue];

--- a/CompactConstraint/NSLayoutConstraint+CompactConstraint.m
+++ b/CompactConstraint/NSLayoutConstraint+CompactConstraint.m
@@ -170,7 +170,7 @@ static CGFloat standardSpacingToView = 8.;
             BOOL constantAfterAddition = [scanner scanUpToCharactersFromSet:rightOperandTerminatingCharacterSet intoString:&rightValueStr];
             NSAssert(constantAfterAddition, @"No constant given after '+' on right side");
             if ([rightValueStr isEqualToString:@"std"] && !rightOperandIsMetric) {
-                if ([leftOperand superview] == rightOperand || [rightOperand superview] == leftOperand) {
+                if ([leftOperand isDescendantOfView:rightOperand] || [rightOperand isDescendantOfView:leftOperand]) {
                     rightConstant = standardSpacingToSuperview;
                 } else {
                     rightConstant = standardSpacingToView;

--- a/CompactConstraint/NSLayoutConstraint+CompactConstraint.m
+++ b/CompactConstraint/NSLayoutConstraint+CompactConstraint.m
@@ -79,6 +79,7 @@ static CGFloat standardSpacingToView = 8.;
 
     BOOL leftOperandScanned = [scanner scanUpToCharactersFromSet:leftOperandTerminatingCharacterSet intoString:&leftOperandStr];
     NSAssert(leftOperandScanned, @"No left operand given");
+    if (leftOperandScanned) {}
     leftOperandStr = [leftOperandStr stringByTrimmingCharactersInSet:leftOperandTerminatingCharacterSet];
     NSRange lastDot = [leftOperandStr rangeOfString:@"." options:NSBackwardsSearch];
     NSAssert1(lastDot.location != NSNotFound, @"Left operand has no property, e.g. '%@.width'", leftOperandStr);
@@ -97,6 +98,7 @@ static CGFloat standardSpacingToView = 8.;
 
     BOOL operatorScanned = [scanner scanCharactersFromSet:operatorCharacterSet intoString:&operatorStr];
     NSAssert(operatorScanned, @"No operator given");
+    if (operatorScanned) {}
     NSLayoutRelation relation;
     if ([operatorStr isEqualToString:@"=="] || [operatorStr isEqualToString:@"="]) relation = NSLayoutRelationEqual;
     else if ([operatorStr isEqualToString:@">="]) relation = NSLayoutRelationGreaterThanOrEqual;
@@ -111,6 +113,7 @@ static CGFloat standardSpacingToView = 8.;
         // right operand is a symbol. Either a metric or a view. Views have dot-properties, metrics don't.
         BOOL rightOperandScanned = [scanner scanUpToCharactersFromSet:rightOperandTerminatingCharacterSet intoString:&rightOperandStr];
         NSAssert(rightOperandScanned, @"No right operand given");
+        if (rightOperandScanned) {}
 
         lastDot = [rightOperandStr rangeOfString:@"." options:NSBackwardsSearch];
         if (lastDot.location == NSNotFound) {
@@ -156,6 +159,7 @@ static CGFloat standardSpacingToView = 8.;
             // see if the scalar is a metric instead of a literal number
             BOOL scalarAfterMultiplication = [scanner scanUpToCharactersFromSet:rightOperandTerminatingCharacterSet intoString:&rightValueStr];
             NSAssert(scalarAfterMultiplication, @"No scalar given after '*' on right side");
+            if (scalarAfterMultiplication) {}
             rightMetricNumber = metrics[rightValueStr];
             NSAssert1(rightMetricNumber, @"Right scalar '%@' not found in metrics dictionary", rightValueStr);
             rightScalar = [rightMetricNumber doubleValue];
@@ -169,6 +173,7 @@ static CGFloat standardSpacingToView = 8.;
             // see if the scalar is a metric instead of a literal number
             BOOL constantAfterAddition = [scanner scanUpToCharactersFromSet:rightOperandTerminatingCharacterSet intoString:&rightValueStr];
             NSAssert(constantAfterAddition, @"No constant given after '+' on right side");
+            if (constantAfterAddition) {}
             if ([rightValueStr isEqualToString:@"std"] && !rightOperandIsMetric) {
                 if ([leftOperand isDescendantOfView:rightOperand] || [rightOperand isDescendantOfView:leftOperand]) {
                     rightConstant = standardSpacingToSuperview;


### PR DESCRIPTION
Added support for iOS standard spacing. Use 'std' as the constant to get the standard spacing, e.g.:
view1.left = view2.right + std

The standard spacing is 20 if it's between a view and a view that contains it, and 8 if it's between a view and it's sibling. Also added a way to change the standard values if your app uses a different metrics.
