### PR TITLE
Add OS X support

### DIFF
--- a/CompactConstraint/UIView+CompactConstraint.h
+++ b/CompactConstraint/UIView+CompactConstraint.h
@@ -5,7 +5,13 @@
 
 #import "NSLayoutConstraint+CompactConstraint.h"
 
-@interface UIView (CompactConstraint)
+#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+    #define CCView UIView
+#elif TARGET_OS_MAC
+    #define CCView NSView
+#endif
+
+@interface CCView (CompactConstraint)
 
 - (NSLayoutConstraint *)addCompactConstraint:(NSString *)relationship metrics:(NSDictionary *)metrics views:(NSDictionary *)views;
 - (NSArray *)addCompactConstraints:(NSArray *)relationshipStrings metrics:(NSDictionary *)metrics views:(NSDictionary *)views;

--- a/CompactConstraint/UIView+CompactConstraint.m
+++ b/CompactConstraint/UIView+CompactConstraint.m
@@ -5,7 +5,7 @@
 
 #import "UIView+CompactConstraint.h"
 
-@implementation UIView (CompactConstraint)
+@implementation CCView (CompactConstraint)
 
 - (NSLayoutConstraint *)addCompactConstraint:(NSString *)relationship metrics:(NSDictionary *)metrics views:(NSDictionary *)views
 {


### PR DESCRIPTION
This was the only change needed to support CompactConstraint on OS X. I tested the change on both OS X and iOS.
