### PR TITLE
Added new NSLayoutAttributes from iOS8 SDK to support layoutMargin

### DIFF
--- a/CompactConstraint/NSLayoutConstraint+CompactConstraint.m
+++ b/CompactConstraint/NSLayoutConstraint+CompactConstraint.m
@@ -67,6 +67,16 @@
             @".centerX" : @(NSLayoutAttributeCenterX),
             @".centerY" : @(NSLayoutAttributeCenterY),
             @".baseline" : @(NSLayoutAttributeBaseline),
+            @".lastBaseline" : @(NSLayoutAttributeLastBaseline),
+            @".firstBaseline" : @(NSLayoutAttributeFirstBaseline),
+            @".leftMargin" : @(NSLayoutAttributeLeftMargin),
+            @".rightMargin" : @(NSLayoutAttributeRightMargin),
+            @".topMargin" : @(NSLayoutAttributeTopMargin),
+            @".bottomMargin" : @(NSLayoutAttributeBottomMargin),
+            @".leadingMargin" :@(NSLayoutAttributeLeadingMargin),
+            @".trailingMargin" :@(NSLayoutAttributeTrailingMargin),
+            @".centerXWithinMargins": @(NSLayoutAttributeCenterXWithinMargins),
+            @".centerYWithinMargins": @(NSLayoutAttributeCenterYWithinMargins)
         };
 
         multiplicationOperatorCharacterSet = [NSCharacterSet characterSetWithCharactersInString:@"*/"];


### PR DESCRIPTION
iOS 8 support a new property to support margins - these are tied to new NSLayoutAttributes

    self.layoutMargin = UIEdgeInset(5,5,5,5);
    [self addCompactConstraints:@["label.left = super.leftMargin",
                                                             "label.right = super.rightMargin" metrics:nil views:self.views];


Additionally - it would be nice if you could update your tags & publish and updated podspec