### PR TITLE
Fix Cocoa include breaking iOS build.

### DIFF
--- a/CompactConstraint/NSLayoutConstraint+CompactConstraint.h
+++ b/CompactConstraint/NSLayoutConstraint+CompactConstraint.h
@@ -3,7 +3,11 @@
 //  Copyright (c) 2014 Marco Arment. See included LICENSE file.
 //
 
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 
 @interface NSLayoutConstraint (CompactConstraint)
 


### PR DESCRIPTION
The last commit broke CompactConstraint on iOS due to including `#import <Cocoa/Cocoa.h>`, which won't be found when targeting iOS. This resolves that with a precompiler check for the correct target/header.